### PR TITLE
feat(startup): add inspection list component (PR2-B)

### DIFF
--- a/web/src/app/dialogs/startup/components/inspection-list.component.html
+++ b/web/src/app/dialogs/startup/components/inspection-list.component.html
@@ -1,0 +1,50 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<div class="list-header">
+  <mat-icon aria-hidden="true">list</mat-icon>
+  <h2>Available inspection data</h2>
+</div>
+
+@if (isLoading()) {
+  <div class="loading-overlay" aria-busy="true">
+    <mat-spinner diameter="40"></mat-spinner>
+    <span>Loading inspections...</span>
+  </div>
+} @else if (items().length > 0) {
+  <div class="list-container">
+    @for (item of items(); track item.id) {
+      <khi-inspection-list-item
+        [item]="item"
+        (openInspectionResult)="openInspectionResult.emit($event)"
+        (openInspectionMetadata)="openInspectionMetadata.emit($event)"
+        (cancelInspection)="cancelInspection.emit($event)"
+        (downloadInspectionResult)="downloadInspectionResult.emit($event)"
+        (changeInspectionTitle)="changeInspectionTitle.emit($event)"
+      />
+    }
+  </div>
+} @else {
+  <div class="empty-state">
+    <p>No recent inspections found.</p>
+    @if (!isViewerMode()) {
+      <button mat-stroked-button (click)="createNewInspection.emit()">
+        New Inspection
+        <mat-icon aria-hidden="true">add</mat-icon>
+      </button>
+    }
+  </div>
+}

--- a/web/src/app/dialogs/startup/components/inspection-list.component.scss
+++ b/web/src/app/dialogs/startup/components/inspection-list.component.scss
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use "@angular/material" as mat;
+
+$empty-text-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 600);
+$title-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 800);
+$icon-color: mat.m2-get-color-from-palette(mat.$m2-blue-palette, 500);
+
+:host {
+  display: grid;
+  grid-template:
+    "header" auto
+    "list" 1fr
+    / 1fr;
+
+  height: 100%;
+  overflow: hidden;
+}
+
+.list-header {
+  grid-area: header;
+  display: grid;
+  grid-template: "icon title" 1fr / auto 1fr;
+  align-items: center;
+  gap: 8px;
+
+  margin-bottom: 16px;
+
+  mat-icon {
+    color: $icon-color;
+  }
+
+  h2 {
+    margin: 0;
+
+    color: $title-color;
+    font-size: 1.2rem;
+    font-weight: 500;
+  }
+}
+
+.list-container {
+  grid-area: list;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  width: 90%;
+  margin: 0 auto;
+  overflow: hidden;
+  overflow-y: auto;
+}
+
+.empty-state {
+  grid-area: list;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+
+  padding: 40px;
+
+  color: $empty-text-color;
+  font-size: 14px;
+}
+
+.loading-overlay {
+  grid-area: list;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+
+  width: 100%;
+  height: 100%;
+
+  color: $empty-text-color;
+}

--- a/web/src/app/dialogs/startup/components/inspection-list.component.spec.ts
+++ b/web/src/app/dialogs/startup/components/inspection-list.component.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { InspectionListComponent } from './inspection-list.component';
+import { By } from '@angular/platform-browser';
+import { InspectionListItemViewModel } from '../types/inspection-activity.model';
+import { Component, input, output } from '@angular/core';
+import { InspectionListItemComponent } from './inspection-list-item.component';
+
+// Mock Component
+@Component({
+  selector: 'khi-inspection-list-item',
+  template: '<div class="mock-item"></div>',
+})
+class MockInspectionListItemComponent {
+  item = input.required<InspectionListItemViewModel>();
+  openInspectionResult = output<string>();
+  openInspectionMetadata = output<string>();
+  cancelInspection = output<string>();
+  downloadInspectionResult = output<string>();
+  changeInspectionTitle = output<{ id: string; changeTo: string }>();
+}
+
+describe('InspectionListComponent', () => {
+  let component: InspectionListComponent;
+  let fixture: ComponentFixture<InspectionListComponent>;
+
+  const mockItems: InspectionListItemViewModel[] = [
+    {
+      id: 'task-1',
+      label: 'Task 1',
+      phase: 'DONE',
+      inspectionTimeLabel: '2026-04-06 12:00:00',
+      totalProgress: {
+        id: 'total-1',
+        percentage: 100,
+        percentageLabel: '100',
+        label: 'Total',
+        message: 'Done',
+        indeterminate: false,
+      },
+      progresses: [],
+      errors: [],
+    },
+    {
+      id: 'task-2',
+      label: 'Task 2',
+      phase: 'RUNNING',
+      inspectionTimeLabel: '2026-04-06 12:05:00',
+      totalProgress: {
+        id: 'total-2',
+        percentage: 50,
+        percentageLabel: '50',
+        label: 'Total',
+        message: 'Running',
+        indeterminate: false,
+      },
+      progresses: [],
+      errors: [],
+    },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [InspectionListComponent],
+    })
+      .overrideComponent(InspectionListComponent, {
+        remove: { imports: [InspectionListItemComponent] },
+        add: { imports: [MockInspectionListItemComponent] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(InspectionListComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('items', mockItems);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render list items', () => {
+    const items = fixture.debugElement.queryAll(
+      By.css('khi-inspection-list-item'),
+    );
+    expect(items.length).toBe(2);
+  });
+
+  it('should show empty state when no items', () => {
+    fixture.componentRef.setInput('items', []);
+    fixture.detectChanges();
+
+    const emptyState = fixture.debugElement.query(By.css('.empty-state'));
+    expect(emptyState).toBeTruthy();
+    expect(emptyState.nativeElement.textContent).toContain(
+      'No recent inspections found.',
+    );
+  });
+
+  it('should show loading state when isLoading is true', () => {
+    fixture.componentRef.setInput('isLoading', true);
+    fixture.detectChanges();
+
+    const loadingOverlay = fixture.debugElement.query(
+      By.css('.loading-overlay'),
+    );
+    expect(loadingOverlay).toBeTruthy();
+    expect(loadingOverlay.nativeElement.textContent).toContain(
+      'Loading inspections...',
+    );
+    expect(loadingOverlay.nativeElement.getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('should show New Inspection button in empty state when not in viewer mode', () => {
+    fixture.componentRef.setInput('items', []);
+    fixture.componentRef.setInput('isViewerMode', false);
+    fixture.detectChanges();
+
+    const button = fixture.debugElement.query(By.css('.empty-state button'));
+    expect(button).toBeTruthy();
+    expect(button.nativeElement.textContent).toContain('New Inspection');
+
+    spyOn(component.createNewInspection, 'emit');
+    button.nativeElement.click();
+    expect(component.createNewInspection.emit).toHaveBeenCalled();
+  });
+
+  it('should not show New Inspection button in empty state when in viewer mode', () => {
+    fixture.componentRef.setInput('items', []);
+    fixture.componentRef.setInput('isViewerMode', true);
+    fixture.detectChanges();
+
+    const button = fixture.debugElement.query(By.css('.empty-state button'));
+    expect(button).toBeFalsy();
+  });
+
+  it('should propagate openInspectionResult event', () => {
+    const itemEl = fixture.debugElement.query(
+      By.css('khi-inspection-list-item'),
+    );
+    const mockItemComponent =
+      itemEl.componentInstance as MockInspectionListItemComponent;
+
+    spyOn(component.openInspectionResult, 'emit');
+    mockItemComponent.openInspectionResult.emit('task-1');
+    expect(component.openInspectionResult.emit).toHaveBeenCalledWith('task-1');
+  });
+
+  it('should propagate openInspectionMetadata event', () => {
+    const mockItemComponent = fixture.debugElement.query(
+      By.css('khi-inspection-list-item'),
+    ).componentInstance;
+    spyOn(component.openInspectionMetadata, 'emit');
+    mockItemComponent.openInspectionMetadata.emit('task-1');
+    expect(component.openInspectionMetadata.emit).toHaveBeenCalledWith(
+      'task-1',
+    );
+  });
+
+  it('should propagate cancelInspection event', () => {
+    const mockItemComponent = fixture.debugElement.query(
+      By.css('khi-inspection-list-item'),
+    ).componentInstance;
+    spyOn(component.cancelInspection, 'emit');
+    mockItemComponent.cancelInspection.emit('task-2');
+    expect(component.cancelInspection.emit).toHaveBeenCalledWith('task-2');
+  });
+
+  it('should propagate downloadInspectionResult event', () => {
+    const mockItemComponent = fixture.debugElement.query(
+      By.css('khi-inspection-list-item'),
+    ).componentInstance;
+    spyOn(component.downloadInspectionResult, 'emit');
+    mockItemComponent.downloadInspectionResult.emit('task-1');
+    expect(component.downloadInspectionResult.emit).toHaveBeenCalledWith(
+      'task-1',
+    );
+  });
+
+  it('should propagate changeInspectionTitle event', () => {
+    const mockItemComponent = fixture.debugElement.query(
+      By.css('khi-inspection-list-item'),
+    ).componentInstance;
+    spyOn(component.changeInspectionTitle, 'emit');
+    const request = { id: 'task-1', changeTo: 'New Title' };
+    mockItemComponent.changeInspectionTitle.emit(request);
+    expect(component.changeInspectionTitle.emit).toHaveBeenCalledWith(request);
+  });
+});

--- a/web/src/app/dialogs/startup/components/inspection-list.component.ts
+++ b/web/src/app/dialogs/startup/components/inspection-list.component.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, input, output } from '@angular/core';
+import { InspectionListItemComponent } from './inspection-list-item.component';
+import {
+  InspectionListItemViewModel,
+  InspectionTitleChangeRequest,
+} from '../types/inspection-activity.model';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatButtonModule } from '@angular/material/button';
+import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
+
+/**
+ * Component for displaying a list of inspection activities.
+ * This is a dumb component that delegates rendering to InspectionListItemComponent.
+ */
+@Component({
+  selector: 'khi-inspection-list',
+  imports: [
+    InspectionListItemComponent,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    MatButtonModule,
+    KHIIconRegistrationModule,
+  ],
+  templateUrl: './inspection-list.component.html',
+  styleUrls: ['./inspection-list.component.scss'],
+})
+export class InspectionListComponent {
+  /** The list of inspection activities to display. */
+  public readonly items = input.required<InspectionListItemViewModel[]>();
+
+  /** Whether the list is loading. */
+  public readonly isLoading = input<boolean>(false);
+
+  /** Whether the application is in viewer mode (read-only). */
+  public readonly isViewerMode = input<boolean>(false);
+
+  /** Emits when the user clicks to create a new inspection from the empty state. */
+  public readonly createNewInspection = output<void>();
+
+  /** Emits the ID of the inspection to open the result for. */
+  public readonly openInspectionResult = output<string>();
+
+  /** Emits the ID of the inspection to open the metadata for. */
+  public readonly openInspectionMetadata = output<string>();
+
+  /** Emits the ID of the inspection to cancel. */
+  public readonly cancelInspection = output<string>();
+
+  /** Emits the ID of the inspection to download the result for. */
+  public readonly downloadInspectionResult = output<string>();
+
+  /** Emits the ID and the new title when an inspection title is changed. */
+  public readonly changeInspectionTitle =
+    output<InspectionTitleChangeRequest>();
+}

--- a/web/src/app/dialogs/startup/components/inspection-list.stories.ts
+++ b/web/src/app/dialogs/startup/components/inspection-list.stories.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryObj } from '@storybook/angular';
+import { InspectionListComponent } from './inspection-list.component';
+import { InspectionListItemViewModel } from '../types/inspection-activity.model';
+
+const meta: Meta<InspectionListComponent> = {
+  title: 'Dialogs/Startup/InspectionListComponent',
+  component: InspectionListComponent,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<InspectionListComponent>;
+
+const mockItems: InspectionListItemViewModel[] = [
+  {
+    id: 'task-1',
+    label: 'Long running task with sub tasks',
+    phase: 'RUNNING',
+    inspectionTimeLabel: '2026-04-06 12:00:00',
+    totalProgress: {
+      id: 'total-1',
+      percentage: 45,
+      percentageLabel: '45',
+      label: 'Total Progress',
+      message: 'Extracting logs...',
+      indeterminate: false,
+    },
+    progresses: [
+      {
+        id: 'sub-1',
+        percentage: 80,
+        percentageLabel: '80',
+        label: 'GKE Node Logs',
+        message: 'Downloading...',
+        indeterminate: false,
+      },
+      {
+        id: 'sub-2',
+        percentage: 10,
+        percentageLabel: '10',
+        label: 'Audit Logs',
+        message: 'Parsing...',
+        indeterminate: false,
+      },
+      {
+        id: 'sub-3',
+        percentage: 0,
+        percentageLabel: '0',
+        label: 'Controller Manager Logs',
+        message: 'Waiting...',
+        indeterminate: true,
+      },
+    ],
+    errors: [],
+  },
+  {
+    id: 'task-2',
+    label: 'Successful completed inspection',
+    phase: 'DONE',
+    inspectionTimeLabel: '2026-04-06 11:30:00',
+    totalProgress: {
+      id: 'total-2',
+      percentage: 100,
+      percentageLabel: '100',
+      label: 'Complete',
+      message: 'Ready',
+      indeterminate: false,
+    },
+    progresses: [],
+    errors: [],
+  },
+  {
+    id: 'task-3',
+    label: 'Failed inspection',
+    phase: 'ERROR',
+    inspectionTimeLabel: '2026-04-06 10:00:00',
+    totalProgress: {
+      id: 'total-3',
+      percentage: 0,
+      percentageLabel: '0',
+      label: 'Failed',
+      message: 'Connection timeout',
+      indeterminate: false,
+    },
+    progresses: [],
+    errors: [
+      {
+        message: 'Failed to connect to cluster: connection timeout after 30s',
+        link: '',
+      },
+    ],
+  },
+];
+
+export const Default: Story = {
+  args: {
+    items: mockItems,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    items: [],
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    items: [],
+    isLoading: true,
+  },
+};


### PR DESCRIPTION
This is PR2-B, split from the original PR2. It contains the `inspection-list` component and depends on PR2-A.